### PR TITLE
Remove extra tickers not in csv

### DIFF
--- a/scripts/utils/cleanup_ticker_files.py
+++ b/scripts/utils/cleanup_ticker_files.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import os
+import sys
+import shutil
+from typing import Set, List, Tuple
+from datetime import datetime
+
+
+def load_allowed_tickers(csv_path: str, column: str) -> Set[str]:
+    alternatives = [column, "Symbol", "Ticker", "SYMBOL", "ticker", "symbol"]
+    with open(csv_path, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        column_name = None
+        for candidate in alternatives:
+            if candidate in fieldnames:
+                column_name = candidate
+                break
+        if not column_name:
+            raise ValueError(
+                f"None of the expected columns {alternatives} were found in CSV: {fieldnames}"
+            )
+        allowed: Set[str] = set()
+        for row in reader:
+            raw = (row.get(column_name) or "").strip()
+            if not raw:
+                continue
+            allowed.add(raw.upper())
+    return allowed
+
+
+def plan_deletions(target_dir: str, allowed: Set[str], mode: str) -> Tuple[List[str], List[str]]:
+    files_to_delete: List[str] = []
+    dirs_to_delete: List[str] = []
+
+    with os.scandir(target_dir) as it:
+        for entry in it:
+            if entry.is_file() and mode in ("all", "files"):
+                basename = os.path.splitext(entry.name)[0]
+                candidate = basename.upper()
+                if candidate not in allowed:
+                    files_to_delete.append(entry.path)
+            elif entry.is_dir() and mode in ("all", "dirs"):
+                candidate = entry.name.upper()
+                if candidate not in allowed:
+                    dirs_to_delete.append(entry.path)
+    return files_to_delete, dirs_to_delete
+
+
+def write_report(path: str, files_to_delete: List[str], dirs_to_delete: List[str]) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("type,path\n")
+        for p in files_to_delete:
+            f.write(f"file,{p}\n")
+        for p in dirs_to_delete:
+            f.write(f"dir,{p}\n")
+
+
+def delete_paths(files_to_delete: List[str], dirs_to_delete: List[str]) -> Tuple[int, int]:
+    deleted_files = 0
+    deleted_dirs = 0
+    for p in files_to_delete:
+        try:
+            os.unlink(p)
+            deleted_files += 1
+        except FileNotFoundError:
+            pass
+    for p in dirs_to_delete:
+        try:
+            shutil.rmtree(p)
+            deleted_dirs += 1
+        except FileNotFoundError:
+            pass
+    return deleted_files, deleted_dirs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove extra ticker files/directories not present in a CSV. "
+            "Names are matched case-insensitively against the CSV ticker column (default: Symbol)."
+        )
+    )
+    parser.add_argument("--csv", required=True, help="Path to CSV containing tickers")
+    parser.add_argument(
+        "--column", default="Symbol", help="CSV column name with tickers (default: Symbol)"
+    )
+    parser.add_argument(
+        "--target-dir", required=True, help="Directory containing ticker-named files/directories"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["all", "files", "dirs"],
+        default="all",
+        help="Delete files, dirs, or both (default: all)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply deletions. Without this flag, runs as dry-run only.",
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help=(
+            "Optional CSV report path of items that would be/were deleted. "
+            "Defaults to ticker_cleanup_<timestamp>.csv in current directory."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    target_dir = os.path.abspath(args.target_dir)
+    csv_path = os.path.abspath(args.csv)
+
+    if not os.path.isdir(target_dir):
+        print(f"ERROR: Target directory not found: {target_dir}")
+        return 2
+    if not os.path.exists(csv_path):
+        print(f"ERROR: CSV file not found: {csv_path}")
+        return 2
+
+    try:
+        allowed = load_allowed_tickers(csv_path, args.column)
+    except Exception as e:
+        print(f"ERROR: Failed to read CSV: {e}")
+        return 2
+
+    files_to_delete, dirs_to_delete = plan_deletions(target_dir, allowed, args.mode)
+
+    total = len(files_to_delete) + len(dirs_to_delete)
+    print(
+        f"Found {total} extra entries in {target_dir} (files: {len(files_to_delete)}, dirs: {len(dirs_to_delete)})."
+    )
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = args.report or os.path.abspath(
+        f"ticker_cleanup_{timestamp}.csv"
+    )
+    write_report(report_path, files_to_delete, dirs_to_delete)
+    print(f"Report written: {report_path}")
+
+    # Preview first few items
+    preview = [os.path.basename(p) for p in (files_to_delete[:10] + dirs_to_delete[:10])]
+    if preview:
+        print("Preview (first up to 10):", ", ".join(preview))
+
+    if not args.apply:
+        print("Dry-run complete. Re-run with --apply to delete.")
+        return 0
+
+    deleted_files, deleted_dirs = delete_paths(files_to_delete, dirs_to_delete)
+    print(
+        f"Deleted {deleted_files} files and {deleted_dirs} directories (of {total} planned)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stocks/management/commands/clean_extra_tickers.py
+++ b/stocks/management/commands/clean_extra_tickers.py
@@ -1,0 +1,157 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from stocks.models import Stock
+import csv
+import os
+from datetime import datetime
+from typing import Set, Tuple
+
+
+class Command(BaseCommand):
+    help = (
+        "Remove extra tickers from the database that are not present in the provided CSV. "
+        "Dry-run by default; use --apply to perform deletions."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--csv",
+            type=str,
+            default="flat-ui__data-Fri Aug 01 2025.csv",
+            help="Path to CSV file containing allowed tickers (default: flat-ui__data-Fri Aug 01 2025.csv)",
+        )
+        parser.add_argument(
+            "--column",
+            type=str,
+            default="Symbol",
+            help="CSV column name that contains ticker symbols (default: Symbol)",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Apply deletions. Without this flag the command runs in dry-run mode.",
+        )
+        parser.add_argument(
+            "--report",
+            type=str,
+            default=None,
+            help=(
+                "Optional path to save a CSV report of tickers that would be/were deleted. "
+                "Defaults to deleted_tickers_<timestamp>.csv in the current directory."
+            ),
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Optional limit on number of deletions to perform (useful for testing).",
+        )
+
+    def handle(self, *args, **options):
+        csv_path: str = options["csv"]
+        csv_column: str = options["column"]
+        apply_changes: bool = options["apply"]
+        report_path: str | None = options["report"]
+        delete_limit: int | None = options["limit"]
+
+        if not os.path.isabs(csv_path):
+            # Resolve relative to project root (manage.py location)
+            csv_path = os.path.abspath(csv_path)
+
+        if not os.path.exists(csv_path):
+            raise CommandError(f"CSV file not found: {csv_path}")
+
+        allowed_tickers: Set[str] = self._load_allowed_tickers(csv_path, csv_column)
+        if not allowed_tickers:
+            raise CommandError(
+                "No tickers were found in the CSV. Verify the file and --column option."
+            )
+
+        # Fetch tickers from DB
+        stocks = Stock.objects.all().only("id", "ticker", "symbol")
+        extras: list[Tuple[int, str, str]] = []
+
+        for s in stocks:
+            ticker_upper = (s.ticker or "").strip().upper()
+            symbol_upper = (s.symbol or "").strip().upper()
+            if ticker_upper not in allowed_tickers and symbol_upper not in allowed_tickers:
+                extras.append((s.id, s.ticker, s.symbol))
+
+        total_extras = len(extras)
+        if total_extras == 0:
+            self.stdout.write(self.style.SUCCESS("No extra tickers found. Database is in sync with CSV."))
+            return
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"Found {total_extras} tickers in DB not present in CSV ({os.path.basename(csv_path)})."
+            )
+        )
+
+        # Prepare report
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        if not report_path:
+            report_path = os.path.abspath(f"deleted_tickers_{timestamp}.csv")
+
+        self._write_report(report_path, extras)
+        self.stdout.write(f"Report written: {report_path}")
+
+        if not apply_changes:
+            preview = ", ".join([t[1] or t[2] or "" for t in extras[:20]])
+            if preview:
+                self.stdout.write(f"Preview (first 20): {preview}")
+            self.stdout.write(self.style.NOTICE("Dry-run complete. Use --apply to delete."))
+            return
+
+        # Apply deletions
+        ids_to_delete = [row[0] for row in extras]
+        if delete_limit is not None:
+            ids_to_delete = ids_to_delete[: max(0, delete_limit)]
+
+        with transaction.atomic():
+            deleted_count, _ = Stock.objects.filter(id__in=ids_to_delete).delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Deleted {deleted_count} Stock rows (out of {total_extras} extras). Report: {report_path}"
+            )
+        )
+
+    def _load_allowed_tickers(self, csv_path: str, csv_column: str) -> Set[str]:
+        """
+        Load allowed tickers from a CSV. If the specified column is missing, attempt
+        to auto-detect from common alternatives.
+        """
+        alternatives = [csv_column, "Symbol", "Ticker", "SYMBOL", "ticker", "symbol"]
+        fieldnames: list[str] | None = None
+        allowed: Set[str] = set()
+
+        with open(csv_path, "r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+            column_name = None
+            for candidate in alternatives:
+                if candidate in fieldnames:
+                    column_name = candidate
+                    break
+
+            if not column_name:
+                raise CommandError(
+                    f"None of the expected columns {alternatives} were found in CSV: {fieldnames}"
+                )
+
+            for row in reader:
+                raw = (row.get(column_name) or "").strip()
+                if not raw:
+                    continue
+                allowed.add(raw.upper())
+
+        return allowed
+
+    def _write_report(self, report_path: str, extras: list[Tuple[int, str, str]]):
+        os.makedirs(os.path.dirname(report_path) or ".", exist_ok=True)
+        with open(report_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["id", "ticker", "symbol"])  # header
+            for row in extras:
+                writer.writerow(row)


### PR DESCRIPTION
Adds scripts to remove extraneous ticker data, both file-based and database entries, by comparing against a CSV.

This PR introduces two distinct cleanup utilities: one for removing physical files and directories named after tickers, and another as a Django management command to remove corresponding database entries (Stock model) that are no longer listed in a given CSV file. Both tools support dry-run and detailed reporting.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0eee909-a8ab-4ce1-9ca2-c53717ac699d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0eee909-a8ab-4ce1-9ca2-c53717ac699d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

