### PR TITLE
Run enhanced stock retrieval script

### DIFF
--- a/stocks/management/commands/update_stocks_yfinance.py
+++ b/stocks/management/commands/update_stocks_yfinance.py
@@ -288,18 +288,10 @@ class Command(BaseCommand):
             return
             
         try:
-            session = requests.Session()
-            session.proxies = {
-                'http': proxy,
-                'https': proxy
-            }
-            session.headers.update({
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-            })
-            import yfinance.shared
-            yfinance.shared._requests = session
+            # yfinance now manages its own curl_cffi session; do not override with requests.Session
+            self.stdout.write("Skipping manual session injection; letting yfinance manage transport")
         except Exception as e:
-            self.stdout.write(f"Failed to set proxy {proxy}: {e}")
+            self.stdout.write(f"Failed to patch yfinance proxy handling: {e}")
 
     def _extract_pe_ratio(self, info):
         """Extract PE ratio with multiple fallback options"""


### PR DESCRIPTION
Allow yfinance to manage its own session to resolve `curl_cffi` errors.

The `yfinance` library, particularly with recent updates, relies on `curl_cffi` for its underlying HTTP requests. Previously, the code was explicitly injecting a `requests.Session` object, which caused compatibility issues and the reported `Yahoo API requires curl_cffi session` errors. This PR removes the custom `requests.Session` usage, allowing `yfinance` to correctly utilize its internal `curl_cffi` session.

---
<a href="https://cursor.com/background-agent?bcId=bc-424b7c5a-71de-4196-9c27-0428da89e1c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-424b7c5a-71de-4196-9c27-0428da89e1c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

