### PR TITLE
Test backend api calls for wordpress and stocks

### DIFF
--- a/stocks/urls.py
+++ b/stocks/urls.py
@@ -10,18 +10,17 @@ urlpatterns = [
     
     # Stock data endpoints - using available api_views functions
     path('stock/<str:ticker>/', api_views.stock_detail_api, name='stock_detail'),
+    # WordPress and search aliases should come BEFORE the generic stocks/<ticker> route
+    path('stocks/search/', api_views.stock_search_api, name='stock_search_wp'),
+    path('search/', api_views.stock_search_api, name='stock_search'),
     path('stocks/<str:ticker>/', api_views.stock_detail_api, name='stock_detail_alias'),
     path('realtime/<str:ticker>/', api_views.realtime_stock_api, name='realtime_stock'),
-    path('search/', api_views.stock_search_api, name='stock_search'),
     path('trending/', api_views.trending_stocks_api, name='trending_stocks'),
     path('market-stats/', api_views.market_stats_api, name='market_stats'),
     # path('nasdaq/', api_views.nasdaq_stocks_api, name='nasdaq_stocks'),  # Removed: only NYSE in DB
     path('stocks/', api_views.stock_list_api, name='stock_list'),
     path('filter/', api_views.filter_stocks_api, name='filter_stocks'),
     path('statistics/', api_views.stock_statistics_api, name='stock_statistics'),
-    
-    # Provide WordPress expected alias for stock search
-    path('stocks/search/', api_views.stock_search_api, name='stock_search_wp'),
     
     # WordPress-friendly endpoints
     path('wordpress/stocks/', WordPressStockView.as_view(), name='wp_stocks'),


### PR DESCRIPTION
Fixes 404s for stock detail and search endpoints, resolves 500 for WordPress subscription, and adds yfinance fallback for stock details.

The 404 errors for stock detail (`/api/stock/AAPL/`) and stock search (`/api/stocks/search/`) were caused by URL pattern collision where the generic `<str:ticker>` pattern was matching "search" or specific tickers before the more specific "search" pattern. Reordering the URL patterns resolves this. The 500 error for WordPress subscription was due to the `EmailSubscription` model requiring a `user` and not having a `category` field, which the previous handler did not account for. A yfinance fallback was also added to `stock_detail_api` to provide basic data for tickers not present in the local database.

---
<a href="https://cursor.com/background-agent?bcId=bc-04547fe8-7d3b-47c2-be58-d2eeaf434e98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04547fe8-7d3b-47c2-be58-d2eeaf434e98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

