### PR TITLE
Fix mysql port conflict

### DIFF
--- a/stockscanner_django/settings.py
+++ b/stockscanner_django/settings.py
@@ -75,48 +75,60 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'stockscanner_django.wsgi.application'
 
-# Database configuration - Auto-detect XAMPP or use environment settings
-if IS_XAMPP_AVAILABLE:
-    # XAMPP Configuration (no password by default)
+# Database configuration - Test mode override, otherwise Auto-detect XAMPP or use environment settings
+TEST_MODE = os.environ.get('TEST_MODE', '').lower() in ('1', 'true', 'yes')
+
+if TEST_MODE:
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': os.environ.get('DB_NAME', 'stockscanner'),
-            'USER': os.environ.get('DB_USER', 'root'),
-            'PASSWORD': os.environ.get('DB_PASSWORD', ''),  # XAMPP default: no password
-            'HOST': os.environ.get('DB_HOST', 'localhost'),
-            'PORT': os.environ.get('DB_PORT', '3306'),
-            'OPTIONS': {
-                'charset': 'utf8mb4',
-                'use_unicode': True,
-                'init_command': "SET sql_mode='STRICT_TRANS_TABLES',innodb_strict_mode=1",
-                'autocommit': True,
-                'connect_timeout': 60,
-                'read_timeout': 300,
-                'write_timeout': 300,
-            },
-            'CONN_MAX_AGE': 0,
-            'ATOMIC_REQUESTS': True,
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'test_db.sqlite3'),
         }
     }
-    print("INFO: Using XAMPP MySQL configuration")
+    print("INFO: TEST_MODE enabled - using SQLite database")
 else:
-    # Standard MySQL configuration
-    DATABASES = {
-        'default': {
-            'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.mysql'),
-            'NAME': os.environ.get('DB_NAME', 'stock_scanner_nasdaq'),
-            'USER': os.environ.get('DB_USER', 'django_user'),
-            'PASSWORD': os.environ.get('DB_PASSWORD', 'StockScanner2010'),
-            'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
-            'PORT': os.environ.get('DB_PORT', '3306'),
-            'OPTIONS': {
-                'charset': 'utf8mb4',
-                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+    # Database configuration - Auto-detect XAMPP or use environment settings
+    if IS_XAMPP_AVAILABLE:
+        # XAMPP Configuration (no password by default)
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.mysql',
+                'NAME': os.environ.get('DB_NAME', 'stockscanner'),
+                'USER': os.environ.get('DB_USER', 'root'),
+                'PASSWORD': os.environ.get('DB_PASSWORD', ''),  # XAMPP default: no password
+                'HOST': os.environ.get('DB_HOST', 'localhost'),
+                'PORT': os.environ.get('DB_PORT', '3306'),
+                'OPTIONS': {
+                    'charset': 'utf8mb4',
+                    'use_unicode': True,
+                    'init_command': "SET sql_mode='STRICT_TRANS_TABLES',innodb_strict_mode=1",
+                    'autocommit': True,
+                    'connect_timeout': 60,
+                    'read_timeout': 300,
+                    'write_timeout': 300,
+                },
+                'CONN_MAX_AGE': 0,
+                'ATOMIC_REQUESTS': True,
             }
         }
-    }
-    print("INFO: Using standard MySQL configuration")
+        print("INFO: Using XAMPP MySQL configuration")
+    else:
+        # Standard MySQL configuration
+        DATABASES = {
+            'default': {
+                'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.mysql'),
+                'NAME': os.environ.get('DB_NAME', 'stock_scanner_nasdaq'),
+                'USER': os.environ.get('DB_USER', 'django_user'),
+                'PASSWORD': os.environ.get('DB_PASSWORD', 'StockScanner2010'),
+                'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
+                'PORT': os.environ.get('DB_PORT', '3306'),
+                'OPTIONS': {
+                    'charset': 'utf8mb4',
+                    'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+                }
+            }
+        }
+        print("INFO: Using standard MySQL configuration")
 
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},

--- a/test_api_fixes.py
+++ b/test_api_fixes.py
@@ -10,6 +10,9 @@ import django
 import json
 from unittest.mock import Mock
 
+# Force test mode to avoid touching MySQL during this script
+os.environ.setdefault('TEST_MODE', '1')
+
 # Set up Django
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'stockscanner_django.settings')
 

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -4,6 +4,10 @@ Comprehensive endpoint testing script for Stock Scanner API
 Tests all major endpoints and reports status
 """
 
+import os
+# Ensure server started by scripts uses SQLite
+os.environ.setdefault('TEST_MODE', '1')
+
 import requests
 import json
 import time

--- a/test_wordpress_endpoints.sh
+++ b/test_wordpress_endpoints.sh
@@ -12,6 +12,9 @@
 
 set -u
 
+# Ensure tests do not use MySQL
+export TEST_MODE=1
+
 BASE_URL="${1:-http://localhost:8000}"
 PYTHON_CMD="python3"
 SERVER_PID=""


### PR DESCRIPTION
Configure Django tests to use SQLite to prevent conflicts on MySQL port 3306.

---
<a href="https://cursor.com/background-agent?bcId=bc-88a85ff8-b288-4684-b1b0-ba07f149f658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88a85ff8-b288-4684-b1b0-ba07f149f658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

