### PR TITLE
Handle local api connection refused error

### DIFF
--- a/stocks/migrations/0002_discount_revenue_tracking.py
+++ b/stocks/migrations/0002_discount_revenue_tracking.py
@@ -5,6 +5,24 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
+def create_ref50_discount(apps, schema_editor):
+    DiscountCode = apps.get_model('stocks', 'DiscountCode')
+    # Create or update REF50 discount code
+    obj, _created = DiscountCode.objects.update_or_create(
+        code='REF50',
+        defaults={
+            'discount_percentage': 50.00,
+            'is_active': True,
+            'applies_to_first_payment_only': True,
+        }
+    )
+
+
+def delete_ref50_discount(apps, schema_editor):
+    DiscountCode = apps.get_model('stocks', 'DiscountCode')
+    DiscountCode.objects.filter(code='REF50').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -70,9 +88,6 @@ class Migration(migrations.Migration):
                 ('last_updated', models.DateTimeField(auto_now=True)),
             ],
         ),
-        # Insert initial REF50 discount code
-        migrations.RunSQL(
-            "INSERT INTO stocks_discountcode (code, discount_percentage, is_active, applies_to_first_payment_only, created_at) VALUES ('REF50', 50.00, 1, 1, NOW()) ON DUPLICATE KEY UPDATE discount_percentage=50.00, is_active=1;",
-            reverse_sql="DELETE FROM stocks_discountcode WHERE code='REF50';"
-        ),
+        # Insert initial REF50 discount code using ORM for cross-database compatibility
+        migrations.RunPython(create_ref50_discount, reverse_code=delete_ref50_discount),
     ]


### PR DESCRIPTION
Enable SQLite support and fix a MySQL-specific migration to facilitate local development and testing.

The original `0002_discount_revenue_tracking.py` migration used MySQL-specific `RunSQL` for `REF50` discount code insertion, which prevented migrations from running on SQLite. This change replaces it with a cross-database `RunPython` operation. Additionally, `settings.py` is updated to allow `DB_ENGINE=django.db.backends.sqlite3` to configure SQLite and avoid applying MySQL-specific connection options when not using MySQL. This resolves connection errors and allows the application to run and be tested with SQLite.

---
<a href="https://cursor.com/background-agent?bcId=bc-82c62135-acd4-4dd9-9416-a3940468c743">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82c62135-acd4-4dd9-9416-a3940468c743">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

