### PR TITLE
Fix syntax error in stock scanner theme

### DIFF
--- a/wordpress_theme/stock-scanner-pro-theme/functions.php
+++ b/wordpress_theme/stock-scanner-pro-theme/functions.php
@@ -1428,7 +1428,7 @@ function stock_scanner_register_user() {
 }
 add_action('wp_ajax_nopriv_stock_scanner_register_user', 'stock_scanner_register_user');
 
-add_action('init', function stock_scanner_ensure_pages(){
+add_action('init', function(){
     $ensure = function($title, $slug, $template, $content = ''){
         if (!get_page_by_path($slug)) {
             $page_id = wp_insert_post(array(


### PR DESCRIPTION
Remove named inline function to fix a PHP parse error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e1f6904-c728-4390-a161-7493990f0bb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e1f6904-c728-4390-a161-7493990f0bb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

