### PR TITLE
Fix unmatched brace in theme functions.php

### DIFF
--- a/wordpress_theme/stock-scanner-pro-theme/functions.php
+++ b/wordpress_theme/stock-scanner-pro-theme/functions.php
@@ -75,7 +75,6 @@ function stock_scanner_scripts() {
         'lazyLoadOffset' => '50px',
         'debounceDelay' => 300
     ));
-}
     
     // Enqueue Chart.js for stock charts
     wp_enqueue_script('chart-js', 'https://cdn.jsdelivr.net/npm/chart.js', array(), '3.9.1', true);


### PR DESCRIPTION
Fix parse error by moving script enqueuing code back into `stock_scanner_scripts()` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bcc7f58-b364-49b5-ae16-ac58d2b81159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bcc7f58-b364-49b5-ae16-ac58d2b81159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

