### PR TITLE
Start cloudflare tunnel and handle errors

### DIFF
--- a/start_tunnel.sh
+++ b/start_tunnel.sh
@@ -70,7 +70,7 @@ start_tunnel() {
         echo "🚀 Starting Cloudflare tunnel (attempt $((retry_count + 1))/$MAX_RETRIES)..."
         
         # Start tunnel with enhanced logging and configuration
-        cloudflared tunnel --loglevel info --protocol quic --retries 5 --max-connection-retries 10 run $TUNNEL_NAME &
+        cloudflared tunnel --loglevel info run $TUNNEL_NAME &
         TUNNEL_PID=$!
         
         # Wait for tunnel to initialize


### PR DESCRIPTION
Removes unsupported flags from `start_tunnel.sh` to fix Cloudflare tunnel startup errors.

The `start_tunnel.sh` script was using `--max-connection-retries`, `--protocol quic`, and `--retries` flags with the `cloudflared tunnel run` command, which are no longer supported or valid for this subcommand, leading to "Incorrect Usage" errors and preventing the tunnel from starting. This PR removes these problematic flags.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9885b6d-5d2a-492d-a9e5-e3ae8ab21635">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9885b6d-5d2a-492d-a9e5-e3ae8ab21635">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

