### PR TITLE
Fix django url import error

### DIFF
--- a/stocks/api_views.py
+++ b/stocks/api_views.py
@@ -11,7 +11,8 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.core.cache import cache
-from django.db.models import Q, F, FieldError
+from django.db.models import Q, F
+from django.core.exceptions import FieldError
 from django.utils import timezone
 from datetime import datetime, timedelta
 import json


### PR DESCRIPTION
Fixes `ImportError` by correcting the import path for `FieldError` in `api_views.py`.

The `FieldError` exception was incorrectly imported from `django.db.models`, leading to an `ImportError` and preventing the Django server from starting. This PR corrects the import to `django.core.exceptions.FieldError`, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-9792fe80-f191-42dc-9f45-bb5ecc8cd673">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9792fe80-f191-42dc-9f45-bb5ecc8cd673">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

