### PR TITLE
Manage tunnel connections and retries

### DIFF
--- a/start_complete_system.sh
+++ b/start_complete_system.sh
@@ -58,12 +58,12 @@ prepare_system() {
     $SUDO mkdir -p "$LOG_DIR"
     $SUDO chown $USER:$USER "$LOG_DIR" 2>/dev/null || true
     
-    # Set up DNS resolution fixes
-    if [ -f "./fix_dns_resolution.sh" ]; then
-        log_message "Applying DNS optimizations..."
+    # Set up DNS resolution fixes (opt-in)
+    if [ "${APPLY_DNS_FIXES:-0}" = "1" ] && [ -f "./fix_dns_resolution.sh" ]; then
+        log_message "Applying DNS optimizations (APPLY_DNS_FIXES=1)..."
         ./fix_dns_resolution.sh
     else
-        log_warning "DNS optimization script not found, skipping"
+        log_warning "Skipping DNS optimization (set APPLY_DNS_FIXES=1 to enable)"
     fi
     
     log_success "System preparation complete"

--- a/start_tunnel.sh
+++ b/start_tunnel.sh
@@ -70,7 +70,7 @@ start_tunnel() {
         echo "🚀 Starting Cloudflare tunnel (attempt $((retry_count + 1))/$MAX_RETRIES)..."
         
         # Start tunnel with enhanced logging and configuration
-        cloudflared tunnel --loglevel info run $TUNNEL_NAME &
+        cloudflared tunnel --loglevel info --protocol http2 --edge-ip-version 4 run $TUNNEL_NAME &
         TUNNEL_PID=$!
         
         # Wait for tunnel to initialize
@@ -173,7 +173,7 @@ echo ""
 echo "Enhanced features:"
 echo "   • Automatic retry on connection failure"
 echo "   • Health monitoring every $HEALTH_CHECK_INTERVAL seconds"
-echo "   • QUIC protocol for better performance"
+echo "   • HTTP/2 protocol over IPv4 for better compatibility"
 echo "   • Graceful shutdown handling"
 echo ""
 echo "Press Ctrl+C to stop all services"

--- a/start_tunnel_simple.sh
+++ b/start_tunnel_simple.sh
@@ -49,7 +49,7 @@ cleanup() {
 trap cleanup SIGINT SIGTERM
 
 echo "🚀 Starting Cloudflare tunnel..."
-cloudflared tunnel run $TUNNEL_NAME &
+cloudflared tunnel --protocol http2 --edge-ip-version 4 run $TUNNEL_NAME &
 TUNNEL_PID=$!
 
 # Wait a moment for tunnel to start


### PR DESCRIPTION
Switched Cloudflare tunnel to HTTP/2 over IPv4 to resolve frequent connection timeouts.

The tunnel logs showed persistent "context canceled" and "QUIC stream timeout" errors, indicating instability with the default QUIC/UDP protocol. Forcing HTTP/2 and IPv4 provides a more stable TCP-based connection, especially in restrictive network environments. Additionally, the tunnel name was unified to `django-api`, the generated `config.yml` structure was corrected, and DNS fixes were made opt-in.

---
<a href="https://cursor.com/background-agent?bcId=bc-703a2d72-341d-4cd9-811f-66a48f5d0629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-703a2d72-341d-4cd9-811f-66a48f5d0629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

