### PR TITLE
Fix syntax error in stock scanner plugin

### DIFF
--- a/stock-scanner-integration.php
+++ b/stock-scanner-integration.php
@@ -79,6 +79,8 @@ class StockScannerIntegration {
         
         // Include PayPal integration
         require_once plugin_dir_path(__FILE__) . 'includes/class-paypal-integration.php';
+    }
+    
     public function settings_notices() {
         if (!current_user_can('manage_options')) return;
         $api_url = get_option('stock_scanner_api_url', '');


### PR DESCRIPTION
Add missing closing brace to `__construct` method to resolve a PHP syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa486603-4d8c-4425-82b6-747f1b48fa58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa486603-4d8c-4425-82b6-747f1b48fa58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

