### PR TITLE
Fix cloudflare tunnel start script

### DIFF
--- a/start_tunnel.sh
+++ b/start_tunnel.sh
@@ -69,11 +69,9 @@ start_tunnel() {
     while [ $retry_count -lt $MAX_RETRIES ]; do
         echo "🚀 Starting Cloudflare tunnel (attempt $((retry_count + 1))/$MAX_RETRIES)..."
 
-        # Correct flags for cloudflared on Windows/MINGW64
+        # Start tunnel with minimal, broadly compatible flags
         cloudflared tunnel run \
-            --protocol auto \
-            --loglevel info \
-            $TUNNEL_NAME &
+            "$TUNNEL_NAME" &
 
         TUNNEL_PID=$!
 


### PR DESCRIPTION
Remove unsupported `--loglevel` and `--protocol` flags from `cloudflared tunnel run` to fix tunnel startup errors on Windows/MINGW64.

---
<a href="https://cursor.com/background-agent?bcId=bc-1427afb3-3c39-41f5-bddc-6433833f3425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1427afb3-3c39-41f5-bddc-6433833f3425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

