### PR TITLE
Diagnose chrome 500 error with copilot

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -188,8 +188,8 @@ if (!defined('WP_DEBUG') || !WP_DEBUG) {
     error_reporting(0);
     
     // Custom error page for fatal errors
-    register_shutdown_function('rts_fatal_error_handler');
-    function rts_fatal_error_handler() {
+    if (!function_exists('rts_fatal_error_handler')) {
+        function rts_fatal_error_handler() {
         $error = error_get_last();
         if ($error && in_array($error['type'], array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE))) {
             if (!headers_sent()) {
@@ -205,6 +205,12 @@ if (!defined('WP_DEBUG') || !WP_DEBUG) {
             }
             exit;
         }
+        }
+    }
+    
+    // Register after ensuring the handler exists
+    if (function_exists('rts_fatal_error_handler')) {
+        register_shutdown_function('rts_fatal_error_handler');
     }
 }
 


### PR DESCRIPTION
Fix `TypeError` (500 error) by defining `rts_fatal_error_handler` before registering it as a shutdown function.

The `register_shutdown_function()` call was made before the `rts_fatal_error_handler` function was defined, leading to a `TypeError` in PHP 8+ environments. This change reorders the code to ensure the function is defined first and adds `function_exists()` checks for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-71b0509e-ec8b-4281-a1fb-c2ac4e8c7e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71b0509e-ec8b-4281-a1fb-c2ac4e8c7e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

