### PR TITLE
Implement server restart kill switch endpoint

### DIFF
--- a/stockscanner_django/settings.py
+++ b/stockscanner_django/settings.py
@@ -197,3 +197,6 @@ LOGGING = {
 }
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 CSRF_TRUSTED_ORIGINS = ["https://api.retailtradescanner.com"]
+KILL_SWITCH_ENABLED = os.environ.get('KILL_SWITCH_ENABLED', 'false').lower() == 'true'
+KILL_SWITCH_PASSWORD = os.environ.get('KILL_SWITCH_PASSWORD', '')
+KILL_SWITCH_DELAY_SECONDS = int(os.environ.get('KILL_SWITCH_DELAY_SECONDS', '5'))

--- a/stockscanner_django/urls.py
+++ b/stockscanner_django/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
-from core.views import homepage, health_check, api_documentation, endpoint_status
+from core.views import homepage, health_check, api_documentation, endpoint_status, kill_switch
 
 urlpatterns = [
     path('', homepage, name='homepage'),
@@ -8,6 +8,7 @@ urlpatterns = [
     path('api/health/', health_check, name='api_health_check'),  # WordPress expects this
     path('docs/', api_documentation, name='api_documentation'),  # API Documentation
     path('endpoint-status/', endpoint_status, name='endpoint_status'),  # Endpoint status check
+    path('kill', kill_switch, name='kill_switch'),  # Kill switch (POST)
     path('admin/', admin.site.urls),
     path('accounts/', include('django.contrib.auth.urls')),  # Authentication URLs
     path('api/', include('stocks.urls')),

--- a/stockscanner_django/urls.py
+++ b/stockscanner_django/urls.py
@@ -8,7 +8,8 @@ urlpatterns = [
     path('api/health/', health_check, name='api_health_check'),  # WordPress expects this
     path('docs/', api_documentation, name='api_documentation'),  # API Documentation
     path('endpoint-status/', endpoint_status, name='endpoint_status'),  # Endpoint status check
-    path('kill', kill_switch, name='kill_switch'),  # Kill switch (POST)
+    path('kill', kill_switch, name='kill_switch'),  # Kill switch (GET/POST)
+    path('kill/', kill_switch, name='kill_switch_slash'),
     path('admin/', admin.site.urls),
     path('accounts/', include('django.contrib.auth.urls')),  # Authentication URLs
     path('api/', include('stocks.urls')),

--- a/templates/core/kill_switch.html
+++ b/templates/core/kill_switch.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+
+{% block title %}Kill Switch | Stock Scanner API{% endblock %}
+
+{% block extra_css %}
+<style>
+    .kill-card { background: var(--bg-white); padding: 1.5rem; border-radius: var(--border-radius-sm); border: 1px solid var(--border-light); box-shadow: var(--shadow-sm); }
+    .warning { background: var(--warning-bg); border: 1px solid var(--error-border); color: var(--error-text); padding: 1rem; border-radius: var(--border-radius-sm); margin-bottom: 1rem; }
+    .success { background: var(--success-bg); border: 1px solid var(--success-border); color: var(--success-text); padding: 1rem; border-radius: var(--border-radius-sm); margin-bottom: 1rem; }
+    .form-group { margin-bottom: 1rem; }
+    .label { display: block; margin-bottom: 0.5rem; color: var(--text-secondary); font-weight: 600; }
+    .input { width: 100%; padding: 0.75rem; border-radius: 8px; border: 1px solid var(--border-light); background: var(--bg-dark); color: var(--text-primary); }
+    .btn-danger { background: var(--error-accent); color: white; border: 0; padding: 0.75rem 1rem; border-radius: 8px; cursor: pointer; font-weight: 700; }
+    .btn-danger:hover { filter: brightness(1.05); }
+    .hint { color: var(--text-light); font-size: 0.9rem; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card kill-card">
+    <h1 style="margin-bottom: .5rem; color: var(--text-primary);">System Kill Switch</h1>
+    <p class="hint" style="margin-bottom: 1rem;">Schedules a system reboot after password verification.</p>
+
+    {% if error %}
+    <div class="warning">{{ error }}</div>
+    {% endif %}
+
+    {% if success %}
+    <div class="success">{{ message }}</div>
+    {% endif %}
+
+    {% if not enabled %}
+    <p class="hint">This feature is currently disabled by configuration.</p>
+    {% else %}
+    <form method="post" action="/kill" style="margin-top: 1rem;">
+        {% csrf_token %}
+        <div class="form-group">
+            <label class="label" for="password">Application Password</label>
+            <input class="input" type="password" id="password" name="password" placeholder="Enter app password" required />
+        </div>
+        <div class="form-group">
+            <label class="label" for="delay">Delay (seconds)</label>
+            <input class="input" type="number" id="delay" name="delay" min="0" step="1" value="" placeholder="Leave blank to use default" />
+            <div class="hint">If specified, overrides the configured delay for this request.</div>
+        </div>
+        <button class="btn-danger" type="submit">Confirm Reboot</button>
+        <a class="btn btn-secondary" href="/" style="margin-left: .5rem;">Cancel</a>
+    </form>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Add a `/kill` endpoint to Django to provide a password-protected kill switch for restarting the server PC.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbcceaa3-04f5-4c99-8e25-9aad6d142e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbcceaa3-04f5-4c99-8e25-9aad6d142e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

