### PR TITLE
Log health and auth requests

### DIFF
--- a/stocks/auth_api.py
+++ b/stocks/auth_api.py
@@ -3,7 +3,7 @@ Authentication and User Management API Views
 Provides comprehensive user authentication, profile management, and billing endpoints
 """
 
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, authentication_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @csrf_exempt
 @api_view(['POST'])
 @permission_classes([AllowAny])
+@authentication_classes([])
 def register_api(request):
     """
     User registration endpoint
@@ -129,6 +130,7 @@ def register_api(request):
 @csrf_exempt
 @api_view(['POST'])
 @permission_classes([AllowAny])
+@authentication_classes([])
 def login_api(request):
     """
     User login endpoint


### PR DESCRIPTION
Add empty authentication classes to login and register APIs to prevent 403 Forbidden errors due to DRF's SessionAuthentication CSRF enforcement.

Although `csrf_exempt` was already applied, Django Rest Framework's `SessionAuthentication` was still performing CSRF checks, leading to 403 errors for unauthenticated POST requests to these `AllowAny` endpoints. Explicitly setting `authentication_classes([])` ensures that `SessionAuthentication` (and its CSRF checks) are bypassed for these specific views, aligning with the intended `csrf_exempt` behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6670770-5525-4769-ad7d-85ba8735fc72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6670770-5525-4769-ad7d-85ba8735fc72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

