### PR TITLE
Handle api login forbidden error

### DIFF
--- a/stocks/auth_urls.py
+++ b/stocks/auth_urls.py
@@ -9,6 +9,7 @@ app_name = 'auth'
 
 urlpatterns = [
     # Authentication endpoints
+    path('auth/csrf/', auth_api.csrf_token_api, name='csrf'),
     path('auth/login/', auth_api.login_api, name='login'),
     path('auth/register/', auth_api.register_api, name='register'),
     path('auth/logout/', auth_api.logout_api, name='logout'),

--- a/stockscanner_django/settings.py
+++ b/stockscanner_django/settings.py
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORimport os
+import os
 from pathlib import Path
 from corsheaders.defaults import default_headers
 
@@ -185,6 +185,7 @@ CORS_ALLOWED_ORIGINS = list(filter(None, [
     'http://127.0.0.1:3000',
     'http://localhost:8000',
     'http://127.0.0.1:8000',
+    'https://api.retailtradescanner.com',
     'https://tradescanpro.com',
     'https://www.tradescanpro.com',
     'https://retailtradescanner.com',
@@ -298,6 +299,7 @@ if _csrf_trusted:
 else:
     CSRF_TRUSTED_ORIGINS = list(filter(None, [
         os.environ.get('PRIMARY_ORIGIN', 'https://api.retailtradescanner.com'),
+        'https://api.retailtradescanner.com',
         'https://tradescanpro.com',
         'https://www.tradescanpro.com',
         'https://retailtradescanner.com',

--- a/stockscanner_django/settings.py
+++ b/stockscanner_django/settings.py
@@ -1,4 +1,4 @@
-import os
+THIS SHOULD BE A LINTER ERRORimport os
 from pathlib import Path
 from corsheaders.defaults import default_headers
 
@@ -187,6 +187,8 @@ CORS_ALLOWED_ORIGINS = list(filter(None, [
     'http://127.0.0.1:8000',
     'https://tradescanpro.com',
     'https://www.tradescanpro.com',
+    'https://retailtradescanner.com',
+    'https://www.retailtradescanner.com',
 ]))
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_METHODS = list({
@@ -298,6 +300,8 @@ else:
         os.environ.get('PRIMARY_ORIGIN', 'https://api.retailtradescanner.com'),
         'https://tradescanpro.com',
         'https://www.tradescanpro.com',
+        'https://retailtradescanner.com',
+        'https://www.retailtradescanner.com',
     ]))
 KILL_SWITCH_ENABLED = os.environ.get('KILL_SWITCH_ENABLED', 'false').lower() == 'true'
 KILL_SWITCH_PASSWORD = os.environ.get('KILL_SWITCH_PASSWORD', '')


### PR DESCRIPTION
Add CSRF token endpoint and update CORS/CSRF origins to resolve 403 Forbidden errors on login.

The login endpoint was returning a 403 due to missing CSRF tokens, as indicated by the "CSRF Failed: CSRF token missing" error. This PR introduces a dedicated endpoint to fetch a CSRF token and ensures the necessary origins are trusted for both CORS and CSRF, facilitating proper cross-origin authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ea26277-1b97-4192-8ea2-97a5b1ede0bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ea26277-1b97-4192-8ea2-97a5b1ede0bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

