### PR TITLE
Configure backend for cross-domain csrf

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from django.middleware.csrf import get_token
 from django.views.decorators.http import require_http_methods
 from django.db import connection
 from django.conf import settings
@@ -370,3 +371,15 @@ def kill_switch(request):
             'message': f'Reboot scheduled in {delay_seconds} seconds'
         })
     return JsonResponse({'success': True, 'message': f'Reboot scheduled in {delay_seconds} seconds'})
+
+# CSRF token endpoint for cross-site SPA
+@ensure_csrf_cookie
+@require_http_methods(["GET", "HEAD", "OPTIONS"])  # Allow preflight
+def csrf(request):
+    """
+    Return a CSRF token in JSON and ensure the CSRF cookie is set.
+    Frontend can call this endpoint with credentials to receive the cookie,
+    and then send the token back in the X-CSRFToken header on subsequent requests.
+    """
+    token = get_token(request)
+    return JsonResponse({'csrfToken': token})

--- a/stockscanner_django/urls.py
+++ b/stockscanner_django/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
-from core.views import homepage, health_check, api_documentation, endpoint_status, endpoint_status_api, kill_switch
+from core.views import homepage, health_check, api_documentation, endpoint_status, endpoint_status_api, kill_switch, csrf
 
 urlpatterns = [
     path('', homepage, name='homepage'),
@@ -9,6 +9,7 @@ urlpatterns = [
     path('docs/', api_documentation, name='api_documentation'),  # API Documentation
     path('endpoint-status/', endpoint_status, name='endpoint_status'),  # Endpoint status check
     path('api/endpoint-status/', endpoint_status_api, name='endpoint_status_api'),
+    path('api/auth/csrf/', csrf, name='csrf'),
     path('kill', kill_switch, name='kill_switch'),  # Kill switch (GET/POST)
     path('kill/', kill_switch, name='kill_switch_slash'),
     path('admin/', admin.site.urls),


### PR DESCRIPTION
Add a CSRF token endpoint to resolve cross-domain CSRF failures for the frontend SPA.

This allows the frontend to fetch the CSRF token via JSON from the API domain, enabling it to send the token in the `X-CSRFToken` header for authenticated requests, bypassing browser restrictions on cookie access across different domains.

---
<a href="https://cursor.com/background-agent?bcId=bc-0548da68-321a-44ed-9abf-0c404ab7d616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0548da68-321a-44ed-9abf-0c404ab7d616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

