### PR TITLE
Changes from background agent bc-049d8eaf-abca-43f6-9022-93c4d390e3dc

### DIFF
--- a/Django/stocks/rate_limit_middleware.py
+++ b/Django/stocks/rate_limit_middleware.py
@@ -305,7 +305,11 @@ class RateLimitMiddleware(MiddlewareMixin):
         Return response when rate limit is exceeded
         """
         cache_key = f"rate_limit_{user_id}"
-        request_data = cache.get(cache_key, {})
+        try:
+            request_data = cache.get(cache_key, {})
+        except Exception:
+            # Fail-open if cache backend is unavailable
+            request_data = {}
         
         # Calculate when the oldest request will expire
         if request_data and request_data.get('requests'):

--- a/Django/stockscanner_django/settings.py
+++ b/Django/stockscanner_django/settings.py
@@ -300,6 +300,10 @@ else:
         }
     }
 
+# Provide a graceful alias so code using caches['redis'] gets the default backend
+if 'redis' not in CACHES:
+    CACHES['redis'] = {**CACHES['default']}
+
 # Sessions in DB (avoid Redis)
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 


### PR DESCRIPTION
Configure Django cache to respect `CACHE_BACKEND` environment variable and add graceful fallback for Redis cache alias.

This resolves `ConnectionError` when Redis is not running by allowing the application to use other configured cache backends (e.g., DB cache) and prevents hard failures if code attempts to access a non-existent 'redis' cache. The rate limit middleware was also updated to fail-open on cache errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-049d8eaf-abca-43f6-9022-93c4d390e3dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-049d8eaf-abca-43f6-9022-93c4d390e3dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

