### PR TITLE
Load screener data on individual page

### DIFF
--- a/core/templates/screener_detail.html
+++ b/core/templates/screener_detail.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .sticky-header { position: sticky; top: 0; background: #fff; z-index: 10; padding: .75rem 0; }
+        .code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const resultsContainer = document.getElementById('results');
+            const statusEl = document.getElementById('status');
+            const apiUrl = '{{ api_url }}';
+            const params = new URLSearchParams({
+                {% for k, v in filters.items %}
+                '{{ k }}': '{{ v }}',
+                {% endfor %}
+            });
+
+            async function runScreener() {
+                try {
+                    statusEl.textContent = 'Running…';
+                    resultsContainer.innerHTML = '<div class="text-muted">Loading…</div>';
+                    const res = await fetch(apiUrl + '?' + params.toString());
+                    const data = await res.json();
+                    statusEl.textContent = 'Done';
+
+                    const rows = (data.stocks || []).map(item => `
+                        <tr>
+                            <td><strong>${item.ticker || ''}</strong></td>
+                            <td>${item.name || ''}</td>
+                            <td>${item.current_price ?? ''}</td>
+                            <td>${item.price_change_percent ?? ''}</td>
+                            <td>${item.volume ?? ''}</td>
+                            <td>${item.market_cap ?? ''}</td>
+                        </tr>
+                    `).join('');
+
+                    resultsContainer.innerHTML = `
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="small text-muted">${(data.total_count ?? 0)} total • ${(data.stocks || []).length} shown</div>
+                            <button id="rerun" class="btn btn-sm btn-outline-secondary">Re-run</button>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover">
+                                <thead class="table-light sticky-header">
+                                    <tr>
+                                        <th>Ticker</th>
+                                        <th>Name</th>
+                                        <th>Price</th>
+                                        <th>Change %</th>
+                                        <th>Volume</th>
+                                        <th>Market Cap</th>
+                                    </tr>
+                                </thead>
+                                <tbody>${rows}</tbody>
+                            </table>
+                        </div>
+                    `;
+
+                    document.getElementById('rerun').addEventListener('click', runScreener);
+                } catch (e) {
+                    statusEl.textContent = 'Error';
+                    resultsContainer.innerHTML = '<div class="text-danger">Failed to load results.</div>';
+                    console.error(e);
+                }
+            }
+
+            // Auto-run on load
+            runScreener();
+        });
+    </script>
+    </head>
+<body>
+    <div class="container py-4">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="h4 mb-0">{{ title }}</h1>
+            <div class="d-flex gap-2">
+                <a href="/screeners/" class="btn btn-outline-secondary">Back</a>
+                <span id="status" class="badge text-bg-secondary align-self-center">Idle</span>
+            </div>
+        </div>
+        <div class="mb-3">
+            <div class="small text-muted">Filters</div>
+            <pre class="code p-2 border rounded bg-light">{{ filters|safe }}</pre>
+        </div>
+        <div id="results"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+

--- a/core/templates/screeners.html
+++ b/core/templates/screeners.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Screeners</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3 mb-0">Stock Screeners</h1>
+        <a class="btn btn-outline-secondary" href="/">Home</a>
+    </div>
+
+    <div class="row g-3">
+        {% for s in screeners %}
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body d-flex flex-column">
+                    <h5 class="card-title">{{ s.title }}</h5>
+                    <p class="card-text small text-muted mb-3">Preconfigured filters ready to run.</p>
+                    <div class="mt-auto d-flex gap-2">
+                        <a href="{{ s.detail_url }}" class="btn btn-primary">Run</a>
+                        <button class="btn btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#filters-{{ s.key }}">View filters</button>
+                    </div>
+                    <div class="collapse mt-3" id="filters-{{ s.key }}">
+                        <pre class="small bg-light border rounded p-2">{{ s.filters|safe }}</pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='core_index'),
+    path('screeners/', views.screeners_list, name='screeners_list'),
+    path('screeners/<str:key>/', views.screener_detail, name='screener_detail'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.http import JsonResponse
+from django.http import JsonResponse, Http404
 from django.views.decorators.csrf import csrf_exempt
 import json
 
@@ -24,3 +24,55 @@ def health_check(request):
         'database': 'connected',
         'version': '1.0.0'
     })
+
+# Predefined screeners and their filters (mapped to /api/market/filter/ params)
+PREDEFINED_SCREENERS = {
+    'high-volume': {
+        'title': 'High Volume Movers',
+        'filters': {
+            'min_volume': '1000000',
+            'order_by': 'volume',
+            'limit': '100'
+        }
+    },
+    'large-cap': {
+        'title': 'Large Cap Stocks',
+        'filters': {
+            'min_market_cap': '10000000000',  # $10B
+            'order_by': 'market_cap',
+            'limit': '100'
+        }
+    },
+    'top-gainers': {
+        'title': 'Top Gainers (Today %)',
+        'filters': {
+            'order_by': 'price_change_percent',
+            'limit': '100'
+        }
+    },
+}
+
+def screeners_list(request):
+    """List available screeners with a run link for each."""
+    screeners = []
+    for key, data in PREDEFINED_SCREENERS.items():
+        screeners.append({
+            'key': key,
+            'title': data.get('title', key.replace('-', ' ').title()),
+            'filters': data.get('filters', {}),
+            'detail_url': f"/screeners/{key}/"
+        })
+    return render(request, 'screeners.html', {'screeners': screeners})
+
+def screener_detail(request, key):
+    """Detail page for a screener that displays the title and filters and auto-runs on load."""
+    config = PREDEFINED_SCREENERS.get(key)
+    if not config:
+        raise Http404('Screener not found')
+    context = {
+        'screener_key': key,
+        'title': config.get('title', key.replace('-', ' ').title()),
+        'filters': config.get('filters', {}),
+        'api_url': '/api/market/filter/'
+    }
+    return render(request, 'screener_detail.html', context)

--- a/stockscanner_django/urls.py
+++ b/stockscanner_django/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('health/', health_check, name='health_check'),
     path('admin/', admin.site.urls),
     path('api/', include('stocks.urls')),
+    path('', include('core.urls')),
 ]


### PR DESCRIPTION
Add screener list and detail pages, where the detail page auto-runs the screener on load, to enable users to view and execute predefined stock screeners.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b7e9b3d-22f4-4fcc-bcc7-3ef5bfcd7aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b7e9b3d-22f4-4fcc-bcc7-3ef5bfcd7aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

